### PR TITLE
Use init false because of init-6

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -10,6 +10,7 @@ arch:
   - aarch64
   - amd64
   - i386
+init: false
 options:
   message: "Hello world..."
 schema:


### PR DESCRIPTION
We used init-6 on the test add-on, so we can disable the docker init binary