### PR TITLE
Write exit code in finish script

### DIFF
--- a/example/rootfs/etc/services.d/example/finish
+++ b/example/rootfs/etc/services.d/example/finish
@@ -6,9 +6,9 @@
 
 declare APP_EXIT_CODE=${1}
 
-if [[ ${APP_EXIT_CODE} -ne 0 ]] && [[ ${APP_EXIT_CODE} -ne 256 ]]; then
+if [[ "${APP_EXIT_CODE}" -ne 0 ]] && [[ "${APP_EXIT_CODE}" -ne 256 ]]; then
   bashio::log.warning "Halt add-on with exit code ${APP_EXIT_CODE}"
-  echo ${APP_EXIT_CODE} > /run/s6-linux-init-container-results/exitcode
+  echo "${APP_EXIT_CODE}" > /run/s6-linux-init-container-results/exitcode
   exec /run/s6/basedir/bin/halt
 fi
 

--- a/example/rootfs/etc/services.d/example/finish
+++ b/example/rootfs/etc/services.d/example/finish
@@ -6,7 +6,7 @@
 
 declare APP_EXIT_CODE=${1}
 
-if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+if [[ ${APP_EXIT_CODE} -ne 0 ]] && [[ ${APP_EXIT_CODE} -ne 256 ]]; then
   bashio::log.warning "Halt add-on with exit code ${APP_EXIT_CODE}"
   echo ${APP_EXIT_CODE} > /run/s6-linux-init-container-results/exitcode
   exec /run/s6/basedir/bin/halt

--- a/example/rootfs/etc/services.d/example/finish
+++ b/example/rootfs/etc/services.d/example/finish
@@ -4,29 +4,12 @@
 # s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
 
-declare RESTART_EXIT_CODE=100
-declare SIGNAL_EXIT_CODE=256
-declare SIGTERM=15
 declare APP_EXIT_CODE=${1}
-declare SIGNAL_NO=${2}
-declare NEW_EXIT_CODE=
 
-bashio::log.info "Example addon finish process exit code ${APP_EXIT_CODE}"
-
-if [[ ${APP_EXIT_CODE} -eq ${RESTART_EXIT_CODE} ]]; then
-  exit 0
-elif [[ ${APP_EXIT_CODE} -eq ${SIGNAL_EXIT_CODE} ]]; then
-  bashio::log.info "Example addon finish process received signal ${SIGNAL_NO}"
-
-  NEW_EXIT_CODE=$((128 + SIGNAL_NO))
-  echo ${NEW_EXIT_CODE} > /run/s6-linux-init-container-results/exitcode
-
-  if [[ ${SIGNAL_NO} -eq ${SIGTERM} ]]; then
-    /run/s6/basedir/bin/halt
-  fi
-else
-  bashio::log.info "Example addon service shutdown"
-
+if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on with exit code ${APP_EXIT_CODE}"
   echo ${APP_EXIT_CODE} > /run/s6-linux-init-container-results/exitcode
-  /run/s6/basedir/bin/halt
+  exec /run/s6/basedir/bin/halt
 fi
+
+bashio::log.info "Service restart after closing"

--- a/example/rootfs/etc/services.d/example/finish
+++ b/example/rootfs/etc/services.d/example/finish
@@ -4,9 +4,29 @@
 # s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
 
-if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
-  bashio::log.warning "Halt add-on"
-  exec /run/s6/basedir/bin/halt
-fi
+declare RESTART_EXIT_CODE=100
+declare SIGNAL_EXIT_CODE=256
+declare SIGTERM=15
+declare APP_EXIT_CODE=${1}
+declare SIGNAL_NO=${2}
+declare NEW_EXIT_CODE=
 
-bashio::log.info "Service restart after closing"
+bashio::log.info "Example addon finish process exit code ${APP_EXIT_CODE}"
+
+if [[ ${APP_EXIT_CODE} -eq ${RESTART_EXIT_CODE} ]]; then
+  exit 0
+elif [[ ${APP_EXIT_CODE} -eq ${SIGNAL_EXIT_CODE} ]]; then
+  bashio::log.info "Example addon finish process received signal ${SIGNAL_NO}"
+
+  NEW_EXIT_CODE=$((128 + SIGNAL_NO))
+  echo ${NEW_EXIT_CODE} > /run/s6-linux-init-container-results/exitcode
+
+  if [[ ${SIGNAL_NO} -eq ${SIGTERM} ]]; then
+    /run/s6/basedir/bin/halt
+  fi
+else
+  bashio::log.info "Example addon service shutdown"
+
+  echo ${APP_EXIT_CODE} > /run/s6-linux-init-container-results/exitcode
+  /run/s6/basedir/bin/halt
+fi


### PR DESCRIPTION
~~Borrowed from https://github.com/home-assistant/core/blob/dev/rootfs/etc/services.d/home-assistant/finish ~~

What we did for HA won't work here. Adjusted to simply write the exit code when we're halting.