### PR TITLE
Use root as the user inside the devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,6 +4,7 @@
   "appPort": ["7123:8123", "7357:4357"],
   "postStartCommand": "bash devcontainer_bootstrap",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
+  "remoteUser":"root",
   "containerEnv": {
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
   },


### PR DESCRIPTION
VSCode has changed the default user to `vscode`, this PR set that back to `root`