### PR TITLE
Add note to developers to set Actions permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Notes to developers after forking or using the github template feature:
   - Make sure you adjust the 'version' key in 'example/config.yaml' when you do that.
   - Make sure you update 'example/CHANGELOG.md' when you do that.
   - The first time this runs you might need to adjust the image configuration on github container registry to make it public
+  - You may also need to adjust the github Actions configuration (Settings > Actions > General > Workflow > Read & Write)
 - Adjust the 'image' key in 'example/config.yaml' so it points to your username instead of 'home-assistant'.
   - This is where the build images will be published to.
 - Rename the example directory.


### PR DESCRIPTION
When I used this template repository, I found this error when the Github action to publish the image ran:

```
INFO: Start upload of ghcr.io/xxxx/amd64-yyyyyy:0.0.1 (attempt #3/3)
FATAL: Upload failed on attempt #3
Error: Process completed with exit code 1.
```

I tried setting the repository to public, with no effect.  

Eventually by setting this permission value, it worked fine.

I think a reminder would avoid people getting stuck like I did.