### PR TITLE
Skip build if image isn't defined

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -83,14 +83,14 @@ jobs:
             echo "Image property is not defined, skipping build"
             echo "build_arch=false" >> $GITHUB_OUTPUT;
           elif [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-              echo "build_arch=true" >> $GITHUB_OUTPUT;
-              echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-              if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-                  echo "BUILD_ARGS=" >> $GITHUB_ENV;
-              fi
-            else
-              echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
-              echo "build_arch=false" >> $GITHUB_OUTPUT;
+            echo "build_arch=true" >> $GITHUB_OUTPUT;
+            echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
+            if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
+                echo "BUILD_ARGS=" >> $GITHUB_ENV;
+            fi
+          else
+            echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
+            echo "build_arch=false" >> $GITHUB_OUTPUT;
           fi
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -79,15 +79,20 @@ jobs:
       - name: Check if add-on should be built
         id: check
         run: |
-          if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-             echo "build_arch=true" >> $GITHUB_OUTPUT;
-             echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-             if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-                 echo "BUILD_ARGS=" >> $GITHUB_ENV;
-             fi
-           else
-             echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
-             echo "build_arch=false" >> $GITHUB_OUTPUT;
+          if [[ "${{ steps.info.outputs.image }}" != "null" ]]; then
+            if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
+                echo "build_arch=true" >> $GITHUB_OUTPUT;
+                echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
+                if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
+                    echo "BUILD_ARGS=" >> $GITHUB_ENV;
+                fi
+              else
+                echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
+                echo "build_arch=false" >> $GITHUB_OUTPUT;
+            fi
+            else
+              echo "Image property is not defined, skipping build"
+              echo "build_arch=false" >> $GITHUB_OUTPUT;
           fi
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -79,19 +79,17 @@ jobs:
       - name: Check if add-on should be built
         id: check
         run: |
-          if [[ "${{ steps.info.outputs.image }}" != "null" ]]; then
-            if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-                echo "build_arch=true" >> $GITHUB_OUTPUT;
-                echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-                if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-                    echo "BUILD_ARGS=" >> $GITHUB_ENV;
-                fi
-              else
-                echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
-                echo "build_arch=false" >> $GITHUB_OUTPUT;
-            fi
+          if [[ "${{ steps.info.outputs.image }}" == "null" ]]; then
+            echo "Image property is not defined, skipping build"
+            echo "build_arch=false" >> $GITHUB_OUTPUT;
+          elif [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
+              echo "build_arch=true" >> $GITHUB_OUTPUT;
+              echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
+              if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
+                  echo "BUILD_ARGS=" >> $GITHUB_ENV;
+              fi
             else
-              echo "Image property is not defined, skipping build"
+              echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
               echo "build_arch=false" >> $GITHUB_OUTPUT;
           fi
 


### PR DESCRIPTION
This change will skip the docker image build if the image property isn't defined in the `config.yaml`. If you choose not to or fail to define `image:` in `config.yaml` it will lint successfully and build ok but will publish an image named `null` which is also less than ideal.