### PR TITLE
Allow automatic builds permission

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -65,6 +65,9 @@ jobs:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
         arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Check out repository

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,7 +1,7 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 ARG BUILD_FROM
 FROM $BUILD_FROM
-LABEL org.opencontainers.image.source=https://github.com/home-assistant/addons-example
+
 # Execute during the build of the image
 ARG TEMPIO_VERSION BUILD_ARCH
 RUN \


### PR DESCRIPTION
This fixes https://github.com/home-assistant/builder/issues/177 for new repos using this template where the user has never pushed a package before.