### PR TITLE
Fix not being able to build addons inside devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -7,6 +7,8 @@
   "containerEnv": {
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
   },
+  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
+  "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "customizations": {
     "vscode": {
       "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],


### PR DESCRIPTION
- Required after https://github.com/home-assistant/supervisor/pull/5974
- Depends on https://github.com/home-assistant/devcontainer/pull/135

/cc @agners 